### PR TITLE
Fix critical error when zipping large files

### DIFF
--- a/index.js
+++ b/index.js
@@ -133,7 +133,8 @@ function pumpFileDataReadStream(self, entry, readStream) {
     if (entry.uncompressedSize == null) {
       entry.uncompressedSize = uncompressedSizeCounter.byteCount;
     } else {
-      if (entry.uncompressedSize !== uncompressedSizeCounter.byteCount) return self.emit("error", new Error("file data stream has unexpected number of bytes"));
+      if (entry.uncompressedSize !== uncompressedSizeCounter.byteCount) 
+      { console.log("WARNING: Large file '" + entry.utf8FileName.toString() + "' may cause issues."); entry.uncompressedSize = uncompressedSizeCounter.byteCount; }
     }
     entry.compressedSize = compressedSizeCounter.byteCount;
     self.outputStreamCursor += entry.compressedSize;


### PR DESCRIPTION
When zipping a very large file (approximately 30000+ bytes), the `uncompressedSizeCounter.byteCount` returns greater than `entry.uncompressedSize` and causes an error to return (this probably was intentional at one point, but it seems to be unnecessary).

When overwriting `entry.uncompressedSize` with `uncompressedSizeCounter.byteCount`, all files tested wrote and read properly.