### PR TITLE
Clarify that the end() callback is different from the end of the stream

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,9 @@ See `addFile()` for the meaning of `mtime` and `mode`.
 #### end([finalSizeCallback])
 
 Indicates that no more files will be added via `addFile()`, `addReadStream()`, or `addBuffer()`.
-Some time after calling this function, `outputStream` will be ended.
+Some time after calling this function, `outputStream` will be ended. Note that this entails that you cannot rely on this
+callback to know when you are done producing output. If for instance you are creating a zip archive on disk, you will need
+to listen to the `end` event on the `outputStream` before notifying consumers of that file.
 
 If specified and non-null, `finalSizeCallback` is given the parameters `(finalSize)`
 sometime during or after the call to `end()`.


### PR DESCRIPTION
I naïvely assumed that the `end()` callback signalled the _actual_ end, including the stream being fully flushed, and used to callback to tell another app to consume the zip. Naturally this sometimes worked except when it raced and didn't. Just thought I'd add a small clarification.