### PR TITLE
Specify that calling end() is necessary

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ See `addFile()` for the meaning of `mtime` and `mode`.
 #### end([options], [finalSizeCallback])
 
 Indicates that no more files will be added via `addFile()`, `addReadStream()`, or `addBuffer()`.
+This method must be called to properly close `outputStream`.
 
 `options` may be omitted or null and has the following structure and default values:
 


### PR DESCRIPTION
If `ZipFile.end()` is not called, then `ZipFile.outputStream` never emits the `close` or `finish` events. The README should mention that calling `end()` is necessary for `outputStream` to close properly.