### PR TITLE
Use 0o-style octal literals

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,11 @@ zipfile.outputStream.pipe(fs.createWriteStream("output.zip")).on("close", functi
 // alternate apis for adding files:
 zipfile.addReadStream(process.stdin, "stdin.txt", {
   mtime: new Date(),
-  mode: parseInt("0100664", 8), // -rw-rw-r--
+  mode: 0o0100664, // -rw-rw-r--
 });
 zipfile.addBuffer(new Buffer("hello"), "hello.txt", {
   mtime: new Date(),
-  mode: parseInt("0100664", 8), // -rw-rw-r--
+  mode: 0o0100664, // -rw-rw-r--
 });
 // call end() after all the files have been added
 zipfile.end();
@@ -100,7 +100,7 @@ See `addFile()` for info about the `metadataPath` parameter.
 ```js
 {
   mtime: new Date(),
-  mode: parseInt("0100664", 8),
+  mode: 0o0100664,
   compress: true,
   forceZip64Format: false,
   size: 12345, // example value
@@ -124,7 +124,7 @@ See `addFile()` for info about the `metadataPath` parameter.
 ```js
 {
   mtime: new Date(),
-  mode: parseInt("0100664", 8),
+  mode: 0o0100664,
   compress: true,
   forceZip64Format: false,
 }

--- a/index.js
+++ b/index.js
@@ -360,8 +360,8 @@ function validateMetadataPath(metadataPath, isDirectory) {
   return metadataPath;
 }
 
-var defaultFileMode = parseInt("0100664", 8);
-var defaultDirectoryMode = parseInt("040775", 8);
+var defaultFileMode = 0o0100664;
+var defaultDirectoryMode = 0o040775;
 
 // this class is not part of the public API
 function Entry(metadataPath, isDirectory, options) {


### PR DESCRIPTION
These have been available in Node.js since 4.0.0.