### PR TITLE
Support for archive + file comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ and causes the eventual close of `outputStream`.
 
 ```js
 {
+  comment: "",
   forceZip64Format: false,
 }
 ```

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ File paths must not end with `"/"`.
   mode: stats.mode,
   compress: true,
   forceZip64Format: false,
+  fileComment: ""
 }
 ```
 
@@ -103,6 +104,7 @@ See `addFile()` for info about the `metadataPath` parameter.
   mode: parseInt("0100664", 8),
   compress: true,
   forceZip64Format: false,
+  fileComment: "",
   size: 12345, // example value
 }
 ```
@@ -127,6 +129,7 @@ See `addFile()` for info about the `metadataPath` parameter.
   mode: parseInt("0100664", 8),
   compress: true,
   forceZip64Format: false,
+  fileComment: ""
 }
 ```
 

--- a/test/test.js
+++ b/test/test.js
@@ -130,8 +130,9 @@ var BufferList = require("bl");
 (function() {
   var zipfile = new yazl.ZipFile();
   var comment = "Hello World";
-  zipfile.comment = comment;
-  zipfile.end(function(finalSize) {
+  zipfile.end({
+    comment: comment
+  }, function(finalSize) {
     if (finalSize === -1) throw new Error("finalSize should be known");
     zipfile.outputStream.pipe(new BufferList(function(err, data) {
       if (err) throw err;


### PR DESCRIPTION
This adds support (and tests) for archive and file comments. Archive comments are set by providing `comment` in `.end()`'s `options`. File comments are set by providing `fileComment` when adding files.