### PR TITLE
Fix running on Node v0.10.48

### DIFF
--- a/index.js
+++ b/index.js
@@ -388,7 +388,7 @@ function Entry(metadataPath, isDirectory, options) {
   if (options.mode != null) {
     this.setFileAttributesMode(options.mode);
   } else {
-    this.setFileAttributesMode(isDirectory ? 0o40775 : 0o100664);
+    this.setFileAttributesMode(isDirectory ? parseInt('40775', 8) : parseInt('100664', 8));
   }
   if (isDirectory) {
     this.crcAndFileSizeKnown = true;


### PR DESCRIPTION
Attempting to require this module on Node v0.10 gives the following error:
```
yazl/index.js:391
    this.setFileAttributesMode(isDirectory ? 0o40775 : 0o100664);
                                             ^
SyntaxError: Unexpected token ILLEGAL
```

Octal literals were not added until ES2015 and not available in Node v0.10.x.

If you run a test through `istanbul cover`, this error apparently does not occur because the instrumentation for coverage reporting is massaging that constant into decimal:
```js
this.setFileAttributesMode(isDirectory ? (__cov_3jDDzS4sgHbw9aLrC2MDAg.b['61'][0]++, 16893) : (__cov_3jDDzS4sgHbw9aLrC2MDAg.b['61'][1]++, 33204));
```
It directly and immediately fails when trying to run `node test/test.js` or `require('yazl')` in Node v0.10.48.

This appears to have been broken for years and no one complained though, so may I instead propose removing v0.10.48 from .travis.yml? =)

Using the old `040775` format directly probably isn't a good idea, since that's a syntax error in strict mode, which modules are loaded as by default in newer versions of Node if using the experimental ES modules features, I believe.

Resolves #61