### PR TITLE
Remove Node v0.10 from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ node_js:
   - 8
   - 6
   - 4
-  - "0.10"
 script:
   - "npm run test-travis"
 after_script:


### PR DESCRIPTION
Despite tests "passing" `yazl` has not ran on Node v0.10.x since 70b0619.

Since no one has complained, probably best just to drop the test instead of ugly workarounds trying to use the right octal format for old and new Node.

Resolves #60