### PR TITLE
Use MAX_LENGTH constant to check buffer size

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,8 @@ var util = require("util");
 var EventEmitter = require("events").EventEmitter;
 var crc32 = require("buffer-crc32");
 
+const MAX_BUFFER_LENGTH = BufferConstants ? BufferConstants.MAX_LENGTH : 0x3fffffff;
+
 exports.ZipFile = ZipFile;
 exports.dateToDosDateTime = dateToDosDateTime;
 
@@ -61,7 +63,7 @@ ZipFile.prototype.addReadStream = function(readStream, metadataPath, options) {
 ZipFile.prototype.addBuffer = function(buffer, metadataPath, options) {
   var self = this;
   metadataPath = validateMetadataPath(metadataPath, false);
-  if (buffer.length > BufferConstants.MAX_LENGTH) throw new Error("buffer too large: " + buffer.length + " > " + BufferConstants.MAX_LENGTH);
+  if (buffer.length > MAX_BUFFER_LENGTH) throw new Error("buffer too large: " + buffer.length + " > " + MAX_BUFFER_LENGTH);
   if (options == null) options = {};
   if (options.size != null) throw new Error("options.size not allowed");
   var entry = new Entry(metadataPath, false, options);

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 var fs = require("fs");
 var Transform = require("stream").Transform;
 var PassThrough = require("stream").PassThrough;
+var BufferConstants = require("buffer").constants;
 var zlib = require("zlib");
 var util = require("util");
 var EventEmitter = require("events").EventEmitter;
@@ -60,7 +61,7 @@ ZipFile.prototype.addReadStream = function(readStream, metadataPath, options) {
 ZipFile.prototype.addBuffer = function(buffer, metadataPath, options) {
   var self = this;
   metadataPath = validateMetadataPath(metadataPath, false);
-  if (buffer.length > 0x3fffffff) throw new Error("buffer too large: " + buffer.length + " > " + 0x3fffffff);
+  if (buffer.length > BufferConstants.MAX_LENGTH) throw new Error("buffer too large: " + buffer.length + " > " + BufferConstants.MAX_LENGTH);
   if (options == null) options = {};
   if (options.size != null) throw new Error("options.size not allowed");
   var entry = new Entry(metadataPath, false, options);


### PR DESCRIPTION
Replace hard-coded constant for max buffer size check with [Buffer MAX_LENGTH](https://nodejs.org/api/buffer.html#buffer_buffer_constants_max_length) when available.