### PR TITLE
docs: fix mode number format

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ If `metadataPath` does not end with a `"/"`, a `"/"` will be appended.
 ```js
 {
   mtime: new Date(),
-  mode: 040775,
+  mode: 0o40775
 }
 ```
 


### PR DESCRIPTION
eslint complained 04775 wasn't a real number and you use the 0o syntax in the project so I thought this would be a nice update to the docs